### PR TITLE
Work around DTR _catalog API strangeness

### DIFF
--- a/registry/json.go
+++ b/registry/json.go
@@ -69,5 +69,17 @@ func getNextLink(base string, resp *http.Response) (string, error) {
 			}
 		}
 	}
+
+	// DTR now uses an `X-Next-Page-Start` header instead of the standard `Link` header;
+	// the value is meant to be used in the `pageStart` query parameter for the next request.
+	if nextPage := resp.Header.Get("X-Next-Page-Start"); nextPage != "" {
+		baseURL, _ := url.Parse(base)
+		q := baseURL.Query()
+		q.Set("pageStart", nextPage)
+		baseURL.RawQuery = q.Encode()
+
+		return baseURL.String(), nil
+	}
+
 	return "", ErrNoMorePages
 }

--- a/registry/repositories.go
+++ b/registry/repositories.go
@@ -131,7 +131,7 @@ func (registry *Registry) tryFallback(ctx context.Context, regChan chan string, 
 
 				// try Harbor fallback
 				regurl = registry.url("/api/projects")
-				registry.Logf("attempting Harbor fallback at %v", regurl)
+				registry.Logf("got error %v, attempting Harbor fallback at %v", err2, regurl)
 				gotSome := false
 				for {
 					var err3 error

--- a/registry/repositories_test.go
+++ b/registry/repositories_test.go
@@ -89,7 +89,7 @@ func harborDataSource(t *testing.T) func(w http.ResponseWriter, r *http.Request)
 
 		if r.URL.Path == "/api/projects" {
 			if h, ok := r.Header["Authorization"]; !ok || len(h) < 1 || h[0] != "Basic dXNlcjpwYXNz" {
-				t.Errorf("Missing or incorrect authorization header %v", h)
+				w.Header().Set("WWW-Authenticate", "Basic")
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}
@@ -131,7 +131,7 @@ func harborDataSource(t *testing.T) func(w http.ResponseWriter, r *http.Request)
 
 		if r.URL.Path == "/api/repositories" {
 			if h, ok := r.Header["Authorization"]; !ok || len(h) < 1 || h[0] != "Basic dXNlcjpwYXNz" {
-				t.Errorf("Missing or incorrect authorization header %v", h)
+				w.Header().Set("WWW-Authenticate", "Basic")
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}

--- a/registry/tokentransport.go
+++ b/registry/tokentransport.go
@@ -12,9 +12,14 @@ type TokenTransport struct {
 	Transport http.RoundTripper
 	Username  string
 	Password  string
+
+	token string
 }
 
 func (t *TokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", t.token))
+	}
 	resp, err := t.Transport.RoundTrip(req)
 	if err != nil {
 		return resp, err
@@ -39,6 +44,8 @@ func (t *TokenTransport) authAndRetry(authService *authService, req *http.Reques
 	if err != nil {
 		return authResp, err
 	}
+
+	t.token = token
 
 	retryResp, err := t.retry(req, token)
 	return retryResp, err


### PR DESCRIPTION
Docker Trusted Registry responds to the `/v2/_catalog` API request with an empty list of repositories, which is invalid. This change attempts to detect this scenario and falls back to using the `/api/v0/repositories` API endpoint to try to get DTR to comply.

DTR _also_ returns a 500 when you call the `/api/v0/repositories` endpoint without a token (one would expect instead to get a 401), so this PR also includes some code to remember the token between requests. This way we can re-use the token we got when trying the `/v2/_catalog` API for the `/api/v0/repositories`.