### PR TITLE
Use basic pre-auth for Harbor API requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module github.com/heroku/docker-registry-client
+
+go 1.13
+
+require (
+	github.com/docker/distribution v2.6.0-rc.1.0.20171011171712-7484e51bf6af+incompatible
+	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7
+	github.com/gorilla/context v1.1.1
+	github.com/gorilla/mux v0.0.0-20160902153343-0a192a193177
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/sirupsen/logrus v0.10.1-0.20160829202321-3ec0642a7fb6
+	golang.org/x/net v0.0.0-20160930002750-a333c534c871
+	golang.org/x/sys v0.0.0-20171017063910-8dbc5d05d6ed
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/docker/distribution v2.6.0-rc.1.0.20171011171712-7484e51bf6af+incompatible h1:32oCUFZJu1F3YxBMijYtDZZqpeZVltPCbWTY+ZbcQyU=
+github.com/docker/distribution v2.6.0-rc.1.0.20171011171712-7484e51bf6af+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 h1:UhxFibDNY/bfvqU5CAUmr9zpesgbU6SWc8/B4mflAE4=
+github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
+github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/mux v0.0.0-20160902153343-0a192a193177/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
+github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/sirupsen/logrus v0.10.1-0.20160829202321-3ec0642a7fb6 h1:kBqWHnHxLrGuyCLS4iCyg7D0Fq/UTsj785X2mcG8Rjs=
+github.com/sirupsen/logrus v0.10.1-0.20160829202321-3ec0642a7fb6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
+golang.org/x/net v0.0.0-20160930002750-a333c534c871/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/sys v0.0.0-20171017063910-8dbc5d05d6ed/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/registry/basictransport.go
+++ b/registry/basictransport.go
@@ -10,9 +10,15 @@ type BasicTransport struct {
 	URL       string
 	Username  string
 	Password  string
+
+	preAuth bool
 }
 
 func (t *BasicTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.preAuth && (t.Username != "" || t.Password != "") {
+		req.SetBasicAuth(t.Username, t.Password)
+	}
+
 	resp, err := t.Transport.RoundTrip(req)
 	if err != nil {
 		return resp, err

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -113,6 +113,14 @@ func (r *Registry) resetToken() {
 	}
 }
 
+func (r *Registry) useBasicPreAuth() {
+	if errorTransport, ok := r.Client.Transport.(*ErrorTransport); ok {
+		if basicAuthTransport, ok := errorTransport.Transport.(*BasicTransport); ok {
+			basicAuthTransport.preAuth = true
+		}
+	}
+}
+
 func (r *Registry) url(pathTemplate string, args ...interface{}) string {
 	pathSuffix := fmt.Sprintf(pathTemplate, args...)
 	url := fmt.Sprintf("%s%s", r.URL, pathSuffix)

--- a/registry/repositories.go
+++ b/registry/repositories.go
@@ -132,6 +132,9 @@ func (registry *Registry) tryFallback(ctx context.Context, regChan chan string, 
 				}
 
 				// try Harbor fallback
+				registry.resetToken()
+				registry.useBasicPreAuth()
+
 				regurl = registry.url("/api/projects")
 				registry.Logf("got error %v, attempting Harbor fallback at %v", err2, regurl)
 				gotSome := false

--- a/registry/repositories_test.go
+++ b/registry/repositories_test.go
@@ -121,8 +121,8 @@ func harborDataSource(t *testing.T) func(w http.ResponseWriter, r *http.Request)
 
 		if r.URL.Path == "/api/projects" {
 			if h, ok := r.Header["Authorization"]; !ok || len(h) < 1 || h[0] != "Basic dXNlcjpwYXNz" {
-				w.Header().Set("WWW-Authenticate", "Basic")
-				w.WriteHeader(http.StatusUnauthorized)
+				w.WriteHeader(http.StatusForbidden)
+				t.Fatal("should use basic pre-auth for Harbor")
 				return
 			}
 


### PR DESCRIPTION
The Harbor API does not behave as expected when sending requests using the OAuth token; critically, it does not return private projects when listing projects.

If we pre-emptively send the user credentials in an `Authorization` header using `Basic` authentication then the API works as expected.
