### PR TITLE
fix: ignore _catalog API response for DTR

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -121,6 +121,19 @@ func (r *Registry) useBasicPreAuth() {
 	}
 }
 
+// isDTR attempts to detect if the registry is DTR; the only hint we get is if during the
+// authentication process we got `service="dtr"` in the OAuth challenge.
+func (r *Registry) isDTR() bool {
+	if errorTransport, ok := r.Client.Transport.(*ErrorTransport); ok {
+		if basicAuthTransport, ok := errorTransport.Transport.(*BasicTransport); ok {
+			if tokenTransport, ok := basicAuthTransport.Transport.(*TokenTransport); ok {
+				return tokenTransport.authService != nil && tokenTransport.authService.Service == "dtr"
+			}
+		}
+	}
+	return false
+}
+
 func (r *Registry) url(pathTemplate string, args ...interface{}) string {
 	pathSuffix := fmt.Sprintf(pathTemplate, args...)
 	url := fmt.Sprintf("%s%s", r.URL, pathSuffix)

--- a/registry/tokentransport.go
+++ b/registry/tokentransport.go
@@ -13,7 +13,8 @@ type TokenTransport struct {
 	Username  string
 	Password  string
 
-	token string
+	token       string
+	authService *authService
 }
 
 func (t *TokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -30,6 +31,7 @@ func (t *TokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 
 		resp, err = t.authAndRetry(authService, req)
+		t.authService = authService
 	}
 	return resp, err
 }


### PR DESCRIPTION
We discovered that the `_catalog` API on DTR sometimes returns
an incomplete list of repositories, where previously we had
thought that it returns an empty list.

We now try to detect that the registry is DTR and ignore the
`_catalog` API response there, preferring to use the repositories
DTR API.